### PR TITLE
added support for ascii code numbers

### DIFF
--- a/angular-hotkeys.js
+++ b/angular-hotkeys.js
@@ -188,6 +188,8 @@
 					keys.push(keyAlias[expr]);
 				} else if (expr.length === 1) {
 					keys.push(expr.toUpperCase().charCodeAt(0));
+				} else if (parseInt(expr) == expr) {
+					keys.push(parseInt(expr));
 				} else {
 					throw new Error('ParseKey expects one character or special expression like "Tab" or "Control", "' + expr + '" given');
 				}


### PR DESCRIPTION
Example:

    {107: numpadPlusAction, 109: numpadMinusAction, 187: plusAction, 189: minusAction}

is now supported

I needed `+` and `-` to work but there was no alias and they were not properly handled

with this change any ascii code can be given in addition to characters or aliases